### PR TITLE
Windows build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,15 +9,19 @@ if [ "$MODE" != "native" ]; then
   echo Forcing a local compiler to be built for $MODE
   WITH_OCAML=1
 elif [ -x "$(command -v ocamlc)" ]; then
-  if [ "$(ocamlc -version)" != "4.07.0" ]; then
+  if [ "$(ocamlc -version | tr -d '\015')" != "4.07.0" ]; then
     echo 'OCaml compiler detected is not 4.07.0, so building local version'
     WITH_OCAML=1
   else
     echo 'Using system OCaml 4.07 compiler'
   fi
 else
-  echo 'OCaml compiler not detected, building a local version of 4.07.0' 
-  WITH_OCAML=1
+  if [ -x $(pwd)/_obj/bin/ocamlc ] ; then
+    export PATH=$(pwd)/_obj/bin:$PATH
+  else
+    echo 'OCaml compiler not detected, building a local version of 4.07.0'
+    WITH_OCAML=1
+  fi
 fi
 
 if [ -x "$(command -v gmake)" ]; then
@@ -52,11 +56,17 @@ if [ $WITH_OCAML -eq 1 ]; then
   cd ../..
 fi
 
-if [ ! -e bootstrap/dune/Makefile -a -d .git ] ; then
-  git submodule update --init bootstrap/dune
-fi
 cd bootstrap/dune
-$MAKE
+if [ ! -x _build/install/default/bin/dune ] ; then
+  if [ ! -e Makefile -a -d ../../.git ] ; then
+    git submodule update --init .
+  fi
+#  git remote add dra27 https://github.com/dra27/dune.git -f
+#  git checkout dra27/let-syntax-crlf
+  $MAKE release
+else
+  ./boot.exe --release || (rm -f boot.exe && $MAKE)
+fi
 cd ../..
 ./bootstrap/dune/_build/install/default/bin/dune build --profile=release --debug-dependency-path @cli
 cp bootstrap/dune/_build/install/default/bin/dune _build/default/output/

--- a/build.sh
+++ b/build.sh
@@ -33,24 +33,87 @@ fi
 
 if [ $WITH_OCAML -eq 1 ]; then
   PREFIX="`pwd`/_obj"
+
   if [ ! -e bootstrap/ocaml/Makefile -a -d .git ] ; then
     git submodule update --init bootstrap/ocaml
   fi
+
   cd bootstrap/ocaml
+
+  if [ -z "$WINPORT" -a -n "$COMSPEC" ]; then
+    # If the current environment provides gcc (could be Cygwin, MSYS2, LXSS) then don't select a
+    # Windows port.
+    if [ ! -x "$(command -v gcc)" ]; then
+      if [ -x "$(command -v cl)" ]; then
+        if cl /nologo /? | grep -q ' for \(AMD64\|x64\)'; then
+          WINPORT=msvc64
+        else
+          WINPORT=msvc
+        fi
+      else
+        # Prefer a 64-bit mingw compiler if we're on a 64-bit machine
+        if [ -x "$(command -v x64_64-w64-mingw32-gcc)" ]; then
+          if [ -x "$(command -v i686-w64-mingw32-gcc)" ]; then
+            if [ "$PROCESSOR_ARCHITEW6432" != "AMD64" -a "$PROCESSOR_ARCHITECTURE" != "AMD64" ]; then
+              WINPORT=mingw
+            else
+              WINPORT=mingw64
+            fi
+          else
+            WINPORT=mingw64
+          fi
+        elif [ -x "$(command -v i686-w64-mingw32-gcc)" ]; then
+          WINPORT=mingw
+        fi
+      fi
+    fi
+  fi
+
+  if [ -z "$WINPORT" ]; then
+    PRE_WORLD=
+    POST_WORLD=
+  else
+    PRE_WORLD=flexdll
+    POST_WORLD=flexlink.opt
+
+    # mingw ports need C++ linking support for ocaml-mccs to work
+    if [ ! -e flexdll/Makefile -a "${WINPORT%64}" = "mingw" ] ; then
+      git submodule update --init flexdll
+      cd flexdll
+      git fetch dra27 || git remote add dra27 https://github.com/dra27/flexdll.git -f
+      git checkout dra27/linking-c++
+      cd ..
+    fi
+
+    # XXX lib munge not required in 4.08+
+    sed -e "/^PREFIX=/s|=.*[[:print:]]|=$(cygpath -m "$PREFIX")|" -e "s|/lib|/lib/ocaml|" config/Makefile.$WINPORT > config/Makefile
+    cp config/s-nt.h byterun/caml/s.h
+    cp config/m-nt.h byterun/caml/m.h
+  fi
+
   case MODE in
   bytecode-only)
-    ./configure --prefix $PREFIX --no-native-compiler
-    $MAKE world
+    if [ -z "$WINPORT" ]; then
+      ./configure --prefix $PREFIX --no-native-compiler
+    fi
+    WORLD=world
     ;;
   flambda)
-    ./configure --prefix $PREFIX --flambda
-    $MAKE world.opt
+    if [ -z "$WINPORT" ]; then
+      ./configure --prefix $PREFIX --flambda
+    else
+      sed -i -e "/^FLAMBDA=/s/false/true/" config/Makefile
+    fi
+    WORLD=world.opt
     ;;
   *)
-    ./configure --prefix $PREFIX
-    $MAKE world.opt
+    WORLD=world.opt
+    if [ -z "$WINPORT" ]; then
+      ./configure --prefix $PREFIX
+    fi
     ;;
   esac
+  $MAKE $PRE_WORLD $WORLD $POST_WORLD
   $MAKE install
   export PATH=$PREFIX/bin:$PATH
   cd ../..


### PR DESCRIPTION
Adds:

 - On-demand use of the locally built compiler
 - Recompilation of Dune on changes
 - Native Windows (outer) support - i.e. `_obj` is correctly set up